### PR TITLE
Configure backend to use nexus.nexilab.co

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
 # Production Environment Configuration
 # Using direct HTTPS connection to Nexus backend
-VITE_API_URL=https://nexus.sudorouter.ai
+VITE_API_URL=https://nexus.nexilab.co
 VITE_API_KEY=

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,13 +7,14 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: 'https://nexus.nexilab.co',
         changeOrigin: true,
-        secure: false,
+        secure: true,
       },
       '/health': {
-        target: 'http://localhost:8080',
+        target: 'https://nexus.nexilab.co',
         changeOrigin: true,
+        secure: true,
       }
     }
   },


### PR DESCRIPTION
## Changes

- Update production API URL from `nexus.sudorouter.ai` to `nexus.nexilab.co`
- Update Vite dev proxy to use HTTPS and `nexus.nexilab.co`
- Enable secure HTTPS connections for all API requests
- Prepare frontend for deployment to Firebase Hosting at `hub.nexilab.co`

## Testing

- ✅ Built successfully for production
- ✅ Deployed to Firebase Hosting
- ✅ Live at: https://nexus-frontend-f36bf.web.app
- ⏳ Custom domain `hub.nexilab.co` pending SSL certificate (Firebase)

## Related

Part of Firebase Hosting setup for custom domain deployment.