### PR TITLE
Fix TypeScript build error in ChatPanel

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -117,7 +117,7 @@ function ChatPanelContent({
   onThreadCreated,
   selectedAgentId,
   filesAPI,
-  userInfo,
+  userInfo: _userInfo,
 }: {
   config: ChatConfig
   onThreadCreated: (threadId: string) => void


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation error that was preventing production builds.

### Changes

- Renamed `userInfo` parameter to `_userInfo` in ChatPanelContent to indicate it's intentionally unused
- This allows the production build to complete successfully

### Testing

- ✅ Production build completes without errors
- ✅ Deployed to Firebase Hosting: https://nexus-frontend-f36bf.web.app

### Context

This fix was needed to deploy the frontend with the new dev backend configuration (`nexus-dev.nexilab.co`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)