### PR TITLE
Add opened file path tracking to LangGraph integration

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -26,6 +26,7 @@ interface ChatPanelProps {
   isOpen: boolean
   onClose: () => void
   initialSelectedAgentId?: string
+  openedFilePath?: string
 }
 
 interface Agent {
@@ -382,7 +383,7 @@ function ChatPanelContent({
   )
 }
 
-export function ChatPanel({ isOpen, onClose, initialSelectedAgentId }: ChatPanelProps) {
+export function ChatPanel({ isOpen, onClose, initialSelectedAgentId, openedFilePath }: ChatPanelProps) {
   const { apiKey, userInfo, apiClient, isAuthenticated } = useAuth()
   const filesAPI = createFilesAPI(apiClient)
   const registerAgentMutation = useRegisterAgent()
@@ -397,6 +398,7 @@ export function ChatPanel({ isOpen, onClose, initialSelectedAgentId }: ChatPanel
     threadId: undefined, // Start with no thread
     userId: userInfo?.subject_id || '',
     tenantId: userInfo?.tenant_id || '',
+    openedFilePath: openedFilePath, // Currently opened file path
   })
   const [showConfig, setShowConfig] = useState(false)
   const [chatKey, setChatKey] = useState(0) // Key to force recreation
@@ -638,6 +640,14 @@ export function ChatPanel({ isOpen, onClose, initialSelectedAgentId }: ChatPanel
       tenantId: userInfo?.tenant_id || prev.tenantId,
     }))
   }, [apiKey, userInfo])
+
+  // Update config when opened file changes
+  useEffect(() => {
+    setConfig(prev => ({
+      ...prev,
+      openedFilePath: openedFilePath,
+    }))
+  }, [openedFilePath])
 
   // Poll sandbox status periodically if sandbox exists
   useEffect(() => {

--- a/src/components/FileBrowser.tsx
+++ b/src/components/FileBrowser.tsx
@@ -318,7 +318,7 @@ export function FileBrowser() {
             <>
               <PanelResizeHandle className="w-1 bg-border hover:bg-blue-500 transition-colors" />
               <Panel defaultSize={30} minSize={20} maxSize={50}>
-                <ChatPanel isOpen={chatPanelOpen} onClose={() => setChatPanelOpen(false)} initialSelectedAgentId={initialSelectedAgentId} />
+                <ChatPanel isOpen={chatPanelOpen} onClose={() => setChatPanelOpen(false)} initialSelectedAgentId={initialSelectedAgentId} openedFilePath={selectedFile?.path} />
               </Panel>
             </>
           )}

--- a/src/hooks/useLangGraph.ts
+++ b/src/hooks/useLangGraph.ts
@@ -11,6 +11,7 @@ interface UseLangGraphOptions {
   userId?: string;
   tenantId?: string;
   sandboxId?: string; // Sandbox ID for code execution
+  openedFilePath?: string; // Currently opened file path in the editor
   key?: number; // Add key to force recreation
 }
 
@@ -27,6 +28,7 @@ export function useLangGraph(options: UseLangGraphOptions = {}) {
     nexusServerUrl: options.nexusServerUrl || 'NOT SET',
     assistantId: options.assistantId,
     sandboxId: options.sandboxId || 'NOT SET',
+    openedFilePath: options.openedFilePath || 'NOT SET',
   });
 
   const stream = useTypedStream({
@@ -40,12 +42,13 @@ export function useLangGraph(options: UseLangGraphOptions = {}) {
 
   // Wrap submit to automatically add metadata
   const submitWithMetadata = (input: any, submitOptions?: any) => {
-    // Add Nexus API key, server URL, and sandbox ID to metadata for tool calls
+    // Add Nexus API key, server URL, sandbox ID, and opened file path to metadata for tool calls
     const metadata = {
       ...submitOptions?.metadata,
       ...(options.nexusApiKey && { x_auth: `Bearer ${options.nexusApiKey}` }),
       ...(options.nexusServerUrl && { nexus_server_url: options.nexusServerUrl }),
       ...(options.sandboxId && { sandbox_id: options.sandboxId }),
+      ...(options.openedFilePath && { opened_file_path: options.openedFilePath }),
     };
 
     return stream.submit(input, {

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -19,4 +19,5 @@ export interface ChatConfig {
   sandboxStatus?: 'running' | 'paused' | 'stopped' | 'unknown';
   sandboxProvider?: string;
   sandboxExpiresAt?: string;
+  openedFilePath?: string; // Currently opened file path in the editor
 }


### PR DESCRIPTION
## Summary
This PR adds tracking of the currently opened file path in the FileBrowser and passes it to the LangGraph agent. This provides the agent with context about which file the user is currently viewing or editing.

## Changes
- Added `openedFilePath` prop to ChatPanel component
- Passed `selectedFile.path` from FileBrowser to ChatPanel
- Extended ChatConfig type to include `openedFilePath`
- Included `opened_file_path` in LangGraph metadata for tool calls
- Added effect to auto-update config when opened file changes

## Benefits
- Agent has better context about user's current focus
- Enables more intelligent file-related suggestions
- Improves overall agent awareness of user's workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)