### PR TITLE
fix: Replace heredoc syntax in Dockerfile for docker-compose 1.x compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,46 +41,7 @@ RUN npm run build
 FROM nginx:alpine
 
 # Copy custom nginx configuration
-COPY <<'EOF' /etc/nginx/conf.d/default.conf
-server {
-    listen 80;
-    server_name _;
-
-    root /usr/share/nginx/html;
-    index index.html;
-
-    # Gzip compression
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 1024;
-    gzip_types text/plain text/css text/xml text/javascript
-               application/x-javascript application/xml+rss
-               application/javascript application/json;
-
-    # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-
-    # React Router: serve index.html for all routes
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-
-    # Static assets caching
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    # Health check endpoint
-    location /health {
-        access_log off;
-        return 200 "healthy\n";
-        add_header Content-Type text/plain;
-    }
-}
-EOF
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,38 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript
+               application/x-javascript application/xml+rss
+               application/javascript application/json;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # React Router: serve index.html for all routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Static assets caching
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Docker build failure on production environments using docker-compose 1.x (legacy builder).

## Problem

The Dockerfile was using Docker Buildx heredoc syntax (`COPY <<EOF`) which is not supported by docker-compose 1.x with the legacy builder. This caused build failures during production deployment:

```
COPY failed: no source files were specified
Service 'frontend' failed to build : Build failed
```

## Solution

- Extract nginx configuration to standalone `nginx.conf` file
- Replace heredoc `COPY` with traditional `COPY nginx.conf` command
- Maintains identical functionality with better compatibility

## Changes

- Created `nginx.conf` with the same nginx configuration
- Modified `Dockerfile` line 44 to use `COPY nginx.conf /etc/nginx/conf.d/default.conf`

## Testing

✅ Tested with docker-compose 1.29.2 (legacy builder): Success
✅ Tested with docker-compose 2.x (buildx): Success
✅ Deployed to production GCP VM: Success

## Related

This fix was discovered during production deployment to GCP with docker-compose 1.29.2 on Ubuntu 22.04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)