### PR TITLE
feat: auto-switch to File tab on file selection

### DIFF
--- a/src/components/FileBrowser.tsx
+++ b/src/components/FileBrowser.tsx
@@ -131,6 +131,8 @@ export function FileBrowser() {
 
   const handleFileSelect = (file: FileInfo) => {
     setSelectedFile(file);
+    // Auto-switch to File tab when a file is selected
+    setViewMode('file');
   };
 
   const handleFileDeleted = () => {


### PR DESCRIPTION
## Summary
- Automatically switch to the File tab when a user clicks on a file in the file tree
- Improves UX by immediately showing the selected file content

## Test plan
- [ ] Click on a file while on the Chat tab
- [ ] Verify that the view automatically switches to File tab
- [ ] Verify the selected file content is displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)